### PR TITLE
Release 2024 v1/relaunch multiple email

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ modules:
       # The maximum amount of time an account can stay valid for without being renewed.
       period: 6w
       # How long before an account expires should Synapse send it a renewal email.
-      renew_at: 1w
+      renew_at: 4w, 1w, 1d
       # Whether to include a link to click in the emails sent to users. If false, only a
       # renewal token is sent, in which case a shorter token is used, and the
       # user will need to copy it into a compatible client that will send an

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ modules:
     config:
       # The maximum amount of time an account can stay valid for without being renewed.
       period: 6w
-      # How long before an account expires should Synapse send it a renewal email.
-      renew_at: 4w, 1w, 1d
+      # How long before an account expires should Synapse send it a renewal email (can send several renewal email).
+      send_renewal_email_at: 4w, 1w, 1d
       # Whether to include a link to click in the emails sent to users. If false, only a
       # renewal token is sent, in which case a shorter token is used, and the
       # user will need to copy it into a compatible client that will send an

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ modules:
       # The maximum amount of time an account can stay valid for without being renewed.
       period: 6w
       # How long before an account expires should Synapse send it a renewal email (can send several renewal email).
-      send_renewal_email_at: 4w, 1w, 1d
+      send_renewal_email_at: ["4w", "1w", "1d"]
       # Whether to include a link to click in the emails sent to users. If false, only a
       # renewal token is sent, in which case a shorter token is used, and the
       # user will need to copy it into a compatible client that will send an

--- a/email_account_validity/_base.py
+++ b/email_account_validity/_base.py
@@ -85,7 +85,7 @@ class EmailAccountValidityBase:
 
         await self.send_renewal_email(user_id, expiration_ts, self._send_renewal_email_at[0])
 
-    async def send_renewal_email(self, user_id: str, expiration_ts: int, period_in_ts: int):
+    async def send_renewal_email(self, user_id: str, expiration_ts: int, renewal_period_in_ts: int):
         """Sends out a renewal email to every email address attached to the given user
         with a unique link allowing them to renew their account.
 
@@ -93,7 +93,7 @@ class EmailAccountValidityBase:
             user_id: ID of the user to send email(s) to.
             expiration_ts: Timestamp in milliseconds for the expiration date of
                 this user's account (used in the email templates).
-            period_in_ts: renewal period
+            renewal_period_in_ts: renewal period
         """
         threepids = await self._api.get_threepids_for_user(user_id)
 
@@ -155,7 +155,7 @@ class EmailAccountValidityBase:
                 text=plain_text,
             )
 
-        await self._store.set_renewal_mail_status(user_id=user_id, period_in_ts=period_in_ts, email_sent=True)
+        await self._store.set_renewal_mail_status(user_id=user_id, renewal_period_in_ts=renewal_period_in_ts, email_sent=True)
 
     async def generate_authenticated_renewal_token(self, user_id: str) -> str:
         """Generates a 8-digit long random string then saves it into the database.

--- a/email_account_validity/_base.py
+++ b/email_account_validity/_base.py
@@ -83,9 +83,9 @@ class EmailAccountValidityBase:
         if expiration_ts is None:
             raise SynapseError(400, "User has no expiration time: %s" % (user_id,))
 
-        await self.send_renewal_email(user_id, expiration_ts)
+        await self.send_renewal_email(user_id, expiration_ts, self._renew_at[0])
 
-    async def send_renewal_email(self, user_id: str, expiration_ts: int):
+    async def send_renewal_email(self, user_id: str, expiration_ts: int, period_in_ts: int):
         """Sends out a renewal email to every email address attached to the given user
         with a unique link allowing them to renew their account.
 
@@ -155,8 +155,7 @@ class EmailAccountValidityBase:
                 text=plain_text,
             )
 
-        for period_in_ts in self._renew_at:
-            await self._store.set_renewal_mail_status(user_id=user_id, period_in_ts=period_in_ts , email_sent=True)
+        await self._store.set_renewal_mail_status(user_id=user_id, period_in_ts=period_in_ts, email_sent=True)
 
     async def generate_authenticated_renewal_token(self, user_id: str) -> str:
         """Generates a 8-digit long random string then saves it into the database.

--- a/email_account_validity/_config.py
+++ b/email_account_validity/_config.py
@@ -20,6 +20,6 @@ import attr
 @attr.s(frozen=True, auto_attribs=True)
 class EmailAccountValidityConfig:
     period: int
-    renew_at: List[int]
-    renew_email_subject: Optional[str] = None
+    send_renewal_email_at: List[int]
+    renewal_email_subject: Optional[str] = None
     send_links: bool = True

--- a/email_account_validity/_config.py
+++ b/email_account_validity/_config.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+from typing import Optional, List
 
 import attr
 
@@ -20,6 +20,6 @@ import attr
 @attr.s(frozen=True, auto_attribs=True)
 class EmailAccountValidityConfig:
     period: int
-    renew_at: int
+    renew_at: List[int]
     renew_email_subject: Optional[str] = None
     send_links: bool = True

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -48,6 +48,7 @@ class EmailAccountValidityStore:
         within Synapse. It populates users in it by batches of 100 in order not to clog up
         the database connection with big requests.
         """
+
         def create_table_txn(txn: LoggingTransaction):
             # Try to create a table for the module.
 
@@ -64,12 +65,12 @@ class EmailAccountValidityStore:
             #                        requires authentication using an access token.
             # * token_used_ts_ms: Timestamp at which the renewal token for the user has
             #                     been used, or NULL if it hasn't been used yet.
+
             txn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS email_account_validity(
                     user_id TEXT PRIMARY KEY,
                     expiration_ts_ms BIGINT NOT NULL,
-                    email_sent BOOLEAN NOT NULL,
                     long_renewal_token TEXT,
                     short_renewal_token TEXT,
                     token_used_ts_ms BIGINT
@@ -90,6 +91,18 @@ class EmailAccountValidityStore:
                 """
                 CREATE UNIQUE INDEX IF NOT EXISTS short_renewal_token_idx
                     ON email_account_validity(short_renewal_token, user_id)
+                """,
+                (),
+            )
+
+            txn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS email_status_account_validity(
+                    user_id TEXT,
+                    period_in_ts BIGINT,
+                    email_sent BOOLEAN NOT NULL,
+                    CONSTRAINT email_status_account_validity_pkey PRIMARY KEY (user_id,period_in_ts)
+                )
                 """,
                 (),
             )
@@ -124,7 +137,6 @@ class EmailAccountValidityStore:
                 retcols=(
                     "user_id",
                     "expiration_ts_ms",
-                    "email_sent",
                     "renewal_token",
                     "token_used_ts_ms",
                 ),
@@ -162,7 +174,6 @@ class EmailAccountValidityStore:
                 keys=[
                     "user_id",
                     "expiration_ts_ms",
-                    "email_sent",
                     "long_renewal_token",
                     "token_used_ts_ms",
                 ],
@@ -170,7 +181,6 @@ class EmailAccountValidityStore:
                     (
                         user["user_id"],
                         user["expiration_ts_ms"],
-                        user["email_sent"],
                         # If there's a renewal token for the user, we consider it's a long
                         # one, because the non-module implementation of account validity
                         # doesn't have a concept of short tokens.
@@ -178,6 +188,33 @@ class EmailAccountValidityStore:
                         user["token_used_ts_ms"],
                     )
                     for user in users_to_insert.values()
+                ],
+            )
+
+            users_period_to_insert = {}
+            for period_in_ts in self._renew_at:
+                for user in users_to_insert.values():
+                    users_period_to_insert[user["user_id"]] = {
+                        "user_id": user["user_id"],
+                        "period_in_ts": period_in_ts,
+                        "email_sent": user["email_sent"]
+                    }
+            # Insert the users in the table.
+            DatabasePool.simple_insert_many_txn(
+                txn=txn,
+                table="email_status_account_validity",
+                keys=[
+                    "user_id",
+                    "period_in_ts",
+                    "email_sent"
+                ],
+                values=[
+                    (
+                        user["user_id"],
+                        user["period_in_ts"],
+                        user["email_sent"]
+                    )
+                    for user in users_period_to_insert.values()
                 ],
             )
 
@@ -211,32 +248,37 @@ class EmailAccountValidityStore:
             A list of dictionaries, each with a user ID and expiration time (in
             milliseconds).
         """
-        def select_users_txn(txn, renew_at):
+
+        def select_users_txn(txn):
             now_ms = int(time.time() * 1000)
 
             txn.execute(
                 """
-                SELECT user_id, expiration_ts_ms FROM email_account_validity
-                WHERE email_sent = ? AND (expiration_ts_ms - ?) <= ?
+                SELECT eav.user_id, eav.expiration_ts_ms, MAX(esav.period_in_ts) as closest_renewal_period
+                FROM email_account_validity eav
+                JOIN email_status_account_validity esav
+                ON eav.user_id = esav.user_id AND esav.email_sent = ?
+                GROUP BY eav.user_id, eav.expiration_ts_ms
+                HAVING (eav.expiration_ts_ms - ?) <= MAX(esav.period_in_ts)
                 """,
-                (False, now_ms, renew_at),
+                (False, now_ms),
             )
             return txn.fetchall()
 
         return await self._api.run_db_interaction(
             "get_users_expiring_soon",
-            select_users_txn,
-            self._renew_at,
+            select_users_txn
         )
 
     async def set_account_validity_for_user(
-        self,
-        user_id: str,
-        expiration_ts: int,
-        email_sent: bool,
-        token_format: TokenFormat,
-        renewal_token: Optional[str] = None,
-        token_used_ts: Optional[int] = None,
+            self,
+            user_id: str,
+            expiration_ts: int,
+            email_sent: bool,
+            renew_at: List[int],
+            token_format: TokenFormat,
+            renewal_token: Optional[str] = None,
+            token_used_ts: Optional[int] = None,
     ):
         """Updates the account validity properties of the given account, with the
         given values.
@@ -248,6 +290,7 @@ class EmailAccountValidityStore:
             email_sent: True means a renewal email has been sent for this account
                 and there's no need to send another one for the current validity
                 period.
+            renew_at: List of period
             token_format: The configured token format, used to determine which
                 column to update.
             renewal_token: Renewal token the user can use to extend the validity
@@ -262,24 +305,43 @@ class EmailAccountValidityStore:
                 INSERT INTO email_account_validity (
                     user_id,
                     expiration_ts_ms,
-                    email_sent,
                     %(token_column_name)s,
                     token_used_ts_ms
                 )
-                VALUES (?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?)
                 ON CONFLICT (user_id) DO UPDATE
                 SET
                     expiration_ts_ms = EXCLUDED.expiration_ts_ms,
-                    email_sent = EXCLUDED.email_sent,
                     %(token_column_name)s = EXCLUDED.%(token_column_name)s,
                     token_used_ts_ms = EXCLUDED.token_used_ts_ms
                 """ % {"token_column_name": _TOKEN_COLUMN_NAME[token_format]},
-                (user_id, expiration_ts, email_sent, renewal_token, token_used_ts)
+                (user_id, expiration_ts, renewal_token, token_used_ts)
             )
 
         await self._api.run_db_interaction(
             "set_account_validity_for_user",
             set_account_validity_for_user_txn,
+        )
+
+        def set_account_status_validity_for_user_txn(txn: LoggingTransaction):
+            for period_in_ts in renew_at:
+                txn.execute(
+                    """
+                    INSERT INTO email_status_account_validity (
+                        user_id,
+                        period_in_ts,
+                        email_sent
+                    )
+                    VALUES (?, ?, ?)
+                    ON CONFLICT (user_id, period_in_ts) DO UPDATE
+                    SET email_sent = EXCLUDED.email_sent
+                    """,
+                    (user_id, period_in_ts, email_sent)
+                )
+
+        await self._api.run_db_interaction(
+            "set_account_validity_for_user",
+            set_account_status_validity_for_user_txn,
         )
 
         await self._api.invalidate_cache(self.get_expiration_ts_for_user, (user_id,))
@@ -311,10 +373,10 @@ class EmailAccountValidityStore:
         return res
 
     async def set_renewal_token_for_user(
-        self,
-        user_id: str,
-        renewal_token: str,
-        token_format: TokenFormat,
+            self,
+            user_id: str,
+            renewal_token: str,
+            token_format: TokenFormat,
     ):
         """Store the given renewal token for the given user.
 
@@ -324,6 +386,7 @@ class EmailAccountValidityStore:
             token_format: The configured token format, used to determine which
                 column to update.
         """
+
         def set_renewal_token_for_user_txn(txn: LoggingTransaction):
             # We don't need to check if the token is unique since we've got unique
             # indexes to check that.
@@ -346,10 +409,10 @@ class EmailAccountValidityStore:
         )
 
     async def validate_renewal_token(
-        self,
-        renewal_token: str,
-        token_format: TokenFormat,
-        user_id: Optional[str] = None,
+            self,
+            renewal_token: str,
+            token_format: TokenFormat,
+            user_id: Optional[str] = None,
     ) -> Tuple[str, int, Optional[int]]:
         """Check if the provided renewal token is associating with a user, optionally
         validating the user it belongs to as well, and return the account renewal status
@@ -408,9 +471,9 @@ class EmailAccountValidityStore:
         )
 
     def set_expiration_date_for_user_txn(
-        self,
-        txn: LoggingTransaction,
-        user_id: str,
+            self,
+            txn: LoggingTransaction,
+            user_id: str,
     ):
         """Sets an expiration date to the account with the given user ID.
 
@@ -421,19 +484,32 @@ class EmailAccountValidityStore:
         expiration_ts = now_ms + self._period
 
         sql = """
-        INSERT INTO email_account_validity (user_id, expiration_ts_ms, email_sent)
-        VALUES (?, ?, ?)
+        INSERT INTO email_account_validity (user_id, expiration_ts_ms)
+        VALUES (?, ?)
         ON CONFLICT (user_id) DO
             UPDATE SET
-                expiration_ts_ms = EXCLUDED.expiration_ts_ms,
-                email_sent = EXCLUDED.email_sent
+                expiration_ts_ms = EXCLUDED.expiration_ts_ms
         """
 
-        txn.execute(sql, (user_id, expiration_ts, False))
+        txn.execute(sql, (user_id, expiration_ts))
+
+        sql = """
+                INSERT INTO email_status_account_validity (
+                    user_id,
+                    period_in_ts,
+                    email_sent
+                )
+                VALUES (?, ?, ?)
+                ON CONFLICT (user_id, period_in_ts) DO UPDATE
+                SET email_sent = EXCLUDED.email_sent
+        """
+
+        for period_in_ts in self._renew_at:
+            txn.execute(sql, (user_id, period_in_ts, False))
 
         txn.call_after(self.get_expiration_ts_for_user.invalidate, (user_id,))
 
-    async def set_renewal_mail_status(self, user_id: str, email_sent: bool) -> None:
+    async def set_renewal_mail_status(self, user_id: str, period_in_ts: int, email_sent: bool) -> None:
         """Sets or unsets the flag that indicates whether a renewal email has been sent
         to the user (and the user hasn't renewed their account yet).
 
@@ -446,8 +522,8 @@ class EmailAccountValidityStore:
         def set_renewal_mail_status_txn(txn: LoggingTransaction):
             DatabasePool.simple_update_one_txn(
                 txn=txn,
-                table="email_account_validity",
-                keyvalues={"user_id": user_id},
+                table="email_status_account_validity",
+                keyvalues={"user_id": user_id, "period_in_ts": period_in_ts},
                 updatevalues={"email_sent": email_sent},
             )
 
@@ -457,9 +533,9 @@ class EmailAccountValidityStore:
         )
 
     async def get_renewal_token_for_user(
-        self,
-        user_id: str,
-        token_format: TokenFormat,
+            self,
+            user_id: str,
+            token_format: TokenFormat,
     ) -> str:
         """Retrieve the renewal token for the given user.
 

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -498,6 +498,14 @@ class EmailAccountValidityStore:
 
         txn.execute(sql, (user_id, expiration_ts))
 
+        txn.execute(
+                """
+                DELETE FROM email_status_account_validity 
+                WHERE user_id = ?
+                """,
+                (user_id,)
+            )
+
         sql = """
                 INSERT INTO email_status_account_validity (
                     user_id,
@@ -505,8 +513,6 @@ class EmailAccountValidityStore:
                     email_sent
                 )
                 VALUES (?, ?, ?)
-                ON CONFLICT (user_id, period_in_ts) DO UPDATE
-                SET email_sent = EXCLUDED.email_sent
         """
 
         for period_in_ts in self._send_renewal_email_at:

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -324,6 +324,13 @@ class EmailAccountValidityStore:
         )
 
         def set_account_status_validity_for_user_txn(txn: LoggingTransaction):
+            txn.execute(
+                """
+                DELETE FROM email_status_account_validity 
+                WHERE user_id = ?
+                """,
+                (user_id,)
+            )
             for period_in_ts in send_renewal_email_at:
                 txn.execute(
                     """
@@ -333,8 +340,6 @@ class EmailAccountValidityStore:
                         email_sent
                     )
                     VALUES (?, ?, ?)
-                    ON CONFLICT (user_id, period_in_ts) DO UPDATE
-                    SET email_sent = EXCLUDED.email_sent
                     """,
                     (user_id, period_in_ts, email_sent)
                 )

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -194,7 +194,7 @@ class EmailAccountValidityStore:
             users_period_to_insert = {}
             for period_in_ts in self._renew_at:
                 for user in users_to_insert.values():
-                    users_period_to_insert[user["user_id"]] = {
+                    users_period_to_insert[f"{user['user_id']}_{period_in_ts}"] = {
                         "user_id": user["user_id"],
                         "period_in_ts": period_in_ts,
                         "email_sent": user["email_sent"]

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -290,7 +290,7 @@ class EmailAccountValidityStore:
             email_sent: True means a renewal email has been sent for this account
                 and there's no need to send another one for the current validity
                 period.
-            send_renewal_email_at: List of period
+            send_renewal_email_at: List of period to know when to send the renewal mail
             token_format: The configured token format, used to determine which
                 column to update.
             renewal_token: Renewal token the user can use to extend the validity

--- a/email_account_validity/account_validity.py
+++ b/email_account_validity/account_validity.py
@@ -165,7 +165,7 @@ class EmailAccountValidity(EmailAccountValidityBase):
                         "User %s has no expiration ts, ignoring" % user["user_id"],
                     )
                     continue
-                logger.debug(f"Sending renewal emails to user_id={user[0]}, expiration_ts={user[1]}, period_in_ts={user[2]}")
+                logger.debug(f"Sending renewal emails to user_id={user[0]}, expiration_ts={user[1]}, renewal_period_in_ts={user[2]}")
                 await self.send_renewal_email(
-                    user_id=user[0], expiration_ts=user[1], period_in_ts=user[2]
+                    user_id=user[0], expiration_ts=user[1], renewal_period_in_ts=user[2]
                 )

--- a/email_account_validity/account_validity.py
+++ b/email_account_validity/account_validity.py
@@ -76,7 +76,7 @@ class EmailAccountValidity(EmailAccountValidityBase):
                 "'send_renewal_email_at' is required when using email account validity"
             )
 
-        send_renewal_email_at = [x.strip() for x in config["send_renewal_email_at"].split(',')]
+        send_renewal_email_at = [x.strip() for x in config["send_renewal_email_at"]]
 
         parsed_config = EmailAccountValidityConfig(
             period=parse_duration(config["period"]),

--- a/email_account_validity/account_validity.py
+++ b/email_account_validity/account_validity.py
@@ -154,8 +154,10 @@ class EmailAccountValidity(EmailAccountValidityBase):
         configuration, and sends renewal emails to all of these users as long as they
         have an email 3PID attached to their account.
         """
+        logger.info("Sending renewal emails")
         expiring_users = await self._store.get_users_expiring_soon()
 
+        logger.debug(f"Sending renewal emails to {len(expiring_users)} users")
         if expiring_users:
             for user in expiring_users:
                 if user[1] is None:
@@ -163,7 +165,7 @@ class EmailAccountValidity(EmailAccountValidityBase):
                         "User %s has no expiration ts, ignoring" % user["user_id"],
                     )
                     continue
-
+                logger.debug(f"Sending renewal emails to user_id={user[0]}, expiration_ts={user[1]}, period_in_ts={user[2]}")
                 await self.send_renewal_email(
                     user_id=user[0], expiration_ts=user[1], period_in_ts=user[2]
                 )

--- a/email_account_validity/account_validity.py
+++ b/email_account_validity/account_validity.py
@@ -76,9 +76,11 @@ class EmailAccountValidity(EmailAccountValidityBase):
                 "'renew_at' is required when using email account validity"
             )
 
+        renew_at = [x.strip() for x in config["renew_at"].split(',')]
+
         parsed_config = EmailAccountValidityConfig(
             period=parse_duration(config["period"]),
-            renew_at=parse_duration(config["renew_at"]),
+            renew_at=[parse_duration(x) for x in renew_at],
             renew_email_subject=config.get("renew_email_subject"),
             send_links=config.get("send_links", True)
         )

--- a/email_account_validity/account_validity.py
+++ b/email_account_validity/account_validity.py
@@ -71,17 +71,17 @@ class EmailAccountValidity(EmailAccountValidityBase):
         if "period" not in config:
             raise ConfigError("'period' is required when using email account validity")
 
-        if "renew_at" not in config:
+        if "send_renewal_email_at" not in config:
             raise ConfigError(
-                "'renew_at' is required when using email account validity"
+                "'send_renewal_email_at' is required when using email account validity"
             )
 
-        renew_at = [x.strip() for x in config["renew_at"].split(',')]
+        send_renewal_email_at = [x.strip() for x in config["send_renewal_email_at"].split(',')]
 
         parsed_config = EmailAccountValidityConfig(
             period=parse_duration(config["period"]),
-            renew_at=[parse_duration(x) for x in renew_at],
-            renew_email_subject=config.get("renew_email_subject"),
+            send_renewal_email_at=[parse_duration(x) for x in send_renewal_email_at],
+            renewal_email_subject=config.get("renewal_email_subject"),
             send_links=config.get("send_links", True)
         )
         return parsed_config
@@ -150,7 +150,7 @@ class EmailAccountValidity(EmailAccountValidityBase):
 
     async def _send_renewal_emails(self):
         """Gets the list of users whose account is expiring in the amount of time
-        configured in the ``renew_at`` parameter from the ``account_validity``
+        configured in the ``send_renewal_email_at`` parameter from the ``account_validity``
         configuration, and sends renewal emails to all of these users as long as they
         have an email 3PID attached to their account.
         """

--- a/email_account_validity/account_validity.py
+++ b/email_account_validity/account_validity.py
@@ -165,5 +165,5 @@ class EmailAccountValidity(EmailAccountValidityBase):
                     continue
 
                 await self.send_renewal_email(
-                    user_id=user[0], expiration_ts=user[1]
+                    user_id=user[0], expiration_ts=user[1], period_in_ts=user[2]
                 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -120,7 +120,7 @@ async def create_account_validity_module(config={}) -> EmailAccountValidity:
     config.update(
         {
             "period": "6w",
-            "renew_at": "1w",
+            "renew_at": "30d, 2w, 1w",
         }
     )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -120,7 +120,7 @@ async def create_account_validity_module(config={}) -> EmailAccountValidity:
     config.update(
         {
             "period": "6w",
-            "send_renewal_email_at": "30d, 2w, 1w",
+            "send_renewal_email_at": ["30d", "2w", "1w"],
         }
     )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -120,7 +120,7 @@ async def create_account_validity_module(config={}) -> EmailAccountValidity:
     config.update(
         {
             "period": "6w",
-            "renew_at": "30d, 2w, 1w",
+            "send_renewal_email_at": "30d, 2w, 1w",
         }
     )
 

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -325,8 +325,15 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
             txn.execute("SELECT user_id FROM email_account_validity", ())
             return txn.fetchall()
 
+        def check_email_status_account_validity(txn: LoggingTransaction):
+            txn.execute("SELECT user_id FROM email_status_account_validity", ())
+            return txn.fetchall()
+
         res = await module._store._api.run_db_interaction("", check_email_account_validity, )
         self.assertEqual(2, len(res))
+
+        res = await module._store._api.run_db_interaction("", check_email_status_account_validity, )
+        self.assertEqual(6, len(res))
 
     async def test_get_users_expiring_soon(self):
         module = await create_account_validity_module()


### PR DESCRIPTION
This PR allows the module to send several renewal emails according to the configured renewal period 


- [x] developement
- [x] unit test
- [x] code refactor : documentation, rewrite test for better understanding, fix linter
- [x] full integration test on dev environnment : manual test with clients

### Note
**If the configuration changes in particular `period` and `send_renewal_email_at`:** 
- we need to reset the module by apply the following statement :
```sql
TRUNCATE TABLE email_account_validity;
TRUNCATE TABLE email_status_account_validity;
```
- restart the module

### Troubleshoot
```sql
-- Display expiration date and configured period
SELECT email_account_validity.user_id, to_char(to_timestamp(email_account_validity.expiration_ts_ms/1000),'YYYY-MM-DD HH24:MI:SS'), to_char(to_timestamp(email_status_account_validity.renewal_period_in_ts/1000),'YYYY-MM-DD HH24:MI:SS'), email_status_account_validity.email_sent FROM email_account_validity LEFT JOIN email_status_account_validity ON email_status_account_validity.user_id = email_account_validity.user_id where email_account_validity.user_id LIKE '%john%';
```