### PR TITLE
Add nb of days before expiration as template parameter for renew email

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The templates the module will use are:
       variable will be `None`.
     * `renewal_token`: The token to use in order to renew the user's account. If
       `send_links` is set to `false`, templates should prefer this variable to `url`.
+    * `nb_days_before_expiracy`: Display number of days before expiration 
 * `account_renewed.html`: The HTML to display to a user when they successfully renew
   their account. It gets passed the following vaiables:
     * `expiration_ts`: A timestamp in milliseconds representing when the account will

--- a/email_account_validity/_base.py
+++ b/email_account_validity/_base.py
@@ -157,11 +157,11 @@ class EmailAccountValidityBase:
 
         await self._store.set_renewal_mail_status(user_id=user_id, email_sent=True)
 
-    def calculate_days_until_expiration(expiration_ts: int) -> int:
+    def calculate_days_until_expiration(self, expiration_ts: int) -> int:
         SECONDS_PER_DAY = 86400
         # Check number of days before expiracy
         now_ms = int(time.time() * 1000)
-        datediff_sec = int((now_ms - expiration_ts) / 1000)
+        datediff_sec = int((expiration_ts - now_ms) / 1000)
 
         if datediff_sec > 0:
             datediff_days = datediff_sec // SECONDS_PER_DAY # convert difference of seconds to days

--- a/email_account_validity/_base.py
+++ b/email_account_validity/_base.py
@@ -134,7 +134,6 @@ class EmailAccountValidityBase:
             renewal_token = await self.generate_authenticated_renewal_token(user_id)
             url = None
 
-
         template_vars = {
             "app_name": self._api.email_app_name,
             "display_name": display_name,

--- a/email_account_validity/_config.py
+++ b/email_account_validity/_config.py
@@ -23,3 +23,4 @@ class EmailAccountValidityConfig:
     renew_at: int
     renew_email_subject: Optional[str] = None
     send_links: bool = True
+

--- a/email_account_validity/_config.py
+++ b/email_account_validity/_config.py
@@ -23,4 +23,3 @@ class EmailAccountValidityConfig:
     renew_at: int
     renew_email_subject: Optional[str] = None
     send_links: bool = True
-

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -309,3 +309,26 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
         #     )
         #
         # self.assertEqual(0, len(res))
+
+    async def test_calculate_days_until_expiration(self):
+
+        module = await create_account_validity_module()
+        # Set the current time to 1 day before the expiration time
+        expiration_ts = int(time.time() * 1000) + (86400 * 1000)
+        self.assertEqual(module.calculate_days_until_expiration(expiration_ts), 1)
+
+        # Set the current time to 2 days after the expiration time
+        expiration_ts = int(time.time() * 1000) - (86400 * 2 * 1000)
+        self.assertEqual(module.calculate_days_until_expiration(expiration_ts), 0)
+
+        # Set the current time to exactly the expiration time
+        expiration_ts = int(time.time() * 1000)
+        self.assertEqual(module.calculate_days_until_expiration(expiration_ts), 0)
+
+        # Set the expiration time to 0, which should result in 0 days until expiration
+        expiration_ts = 0
+        self.assertEqual(module.calculate_days_until_expiration(expiration_ts), 0)
+
+        # Set the expiration time to a negative value, which should result in 0 days until expiration
+        expiration_ts = -1000
+        self.assertEqual(module.calculate_days_until_expiration(expiration_ts), 0)


### PR DESCRIPTION
## Description
Before making this addition i checked if it was easy to get the current time inside jinja templates and I only found 2 solutions : 
- injecting datetime/time as template parameter -> still need to have an addition outside the template.
- injecting a global method inside the rendering engine just like `format_ts` in synapse (`template.py`) -> which means touching the synapse code 

That's why I decided to directly inject the number of days with the calculation in the module. TBD if there can be another solution. However the styling part was reported directly to the template, cf https://github.com/tchapgouv/tchap-infra/pull/2674


## Tests
- [x] test method test_calculate_days_until_expiration
- [x] Displaying in the mail template