### PR TITLE
fix the data migration from account_validity to email_account_validity

### DIFF
--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -137,6 +137,7 @@ class EmailAccountValidityStore:
                 retcols=(
                     "user_id",
                     "expiration_ts_ms",
+                    "email_sent",
                     "renewal_token",
                     "token_used_ts_ms",
                 ),
@@ -146,7 +147,13 @@ class EmailAccountValidityStore:
             # of registered users on the homeserver.
             users_to_insert = {}
             for row in rows:
-                users_to_insert[row["user_id"]] = row
+                users_to_insert[row[0]] = {
+                        "user_id": row[0],
+                        "expiration_ts_ms": row[1],
+                        "email_sent": row[2],
+                        "renewal_token": row[3],
+                        "token_used_ts_ms": row[4],
+                    }
 
             # Look for users that are registered but don't have a state in the
             # account_validity table, and set a default state for them. This default

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -314,6 +314,18 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
                 """,
                 (),
             )
+            txn.execute(
+                """
+                INSERT INTO account_validity VALUES (
+                    "@john.doe-synapse.org:dev01.synapse.org",
+                    1700823100,
+                    false,
+                    "mytoken",
+                    1700823160
+                );
+                """,
+                (),
+            )
 
         populate_users = True
         module = await create_account_validity_module()


### PR DESCRIPTION
Fix the migration of account validity from synapse to this module table email_account_validity.