### PR TITLE
remove the data migration from account_validity to email_account_validity

### DIFF
--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -146,7 +146,13 @@ class EmailAccountValidityStore:
             # of registered users on the homeserver.
             users_to_insert = {}
             for row in rows:
-                users_to_insert[row["user_id"]] = row
+                users_to_insert[row[0]] = {
+                        "user_id": row[0],
+                        "expiration_ts_ms": row[1],
+                        "email_sent": False,
+                        "renewal_token": row[2],
+                        "token_used_ts_ms": row[3],
+                    }
 
             # Look for users that are registered but don't have a state in the
             # account_validity table, and set a default state for them. This default

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -116,6 +116,7 @@ class EmailAccountValidityStore:
                 LEFT JOIN email_account_validity
                     ON (users.name = email_account_validity.user_id)
                 WHERE email_account_validity.user_id IS NULL
+                AND users.deactivated = 0
                 LIMIT ?
                 """,
                 (batch_size,),
@@ -125,34 +126,9 @@ class EmailAccountValidityStore:
             if not missing_users:
                 return 0
 
-            # Figure out the state of these users in the account_validity table.
-            # Note that at some point we'll want to get rid of the account_validity table
-            # and we'll need to get rid of this code as well.
-            rows = DatabasePool.simple_select_many_txn(
-                txn=txn,
-                table="account_validity",
-                column="user_id",
-                iterable=tuple([user[0] for user in missing_users]),
-                keyvalues={},
-                retcols=(
-                    "user_id",
-                    "expiration_ts_ms",
-                    "renewal_token",
-                    "token_used_ts_ms",
-                ),
-            )
-
             # Turn the results into a dictionary so we can later merge it with the list
             # of registered users on the homeserver.
             users_to_insert = {}
-            for row in rows:
-                users_to_insert[row[0]] = {
-                        "user_id": row[0],
-                        "expiration_ts_ms": row[1],
-                        "email_sent": False,
-                        "renewal_token": row[2],
-                        "token_used_ts_ms": row[3],
-                    }
 
             # Look for users that are registered but don't have a state in the
             # account_validity table, and set a default state for them. This default

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -314,6 +314,18 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
                 """,
                 (),
             )
+            txn.execute(
+                """
+                INSERT INTO account_validity VALUES (
+                    "@john.doe-synapse.org:dev01.synapse.org",
+                    1700823100,
+                    false,
+                    "mytoken",
+                    1700823160
+                );
+                """,
+                (),
+            )
 
         populate_users = True
         module = await create_account_validity_module()

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -275,6 +275,7 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
                 password_hash TEXT,
                 creation_ts BIGINT UNSIGNED,
                 admin BOOL DEFAULT 0 NOT NULL,
+                deactivated smallint DEFAULT 0 NOT NULL,
                 UNIQUE(name)
                 );
                 """,
@@ -286,6 +287,7 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
                     "@jane.doe-synapse.org:dev01.synapse.org",
                     "$2b$12$58YVjKsB58DM.YFChWQM8uP0x3rh1iaKDNSPl3Jv34LGqwn7tIure",
                     1700823133,
+                    0,
                     0
                 );
                 """,
@@ -297,7 +299,20 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
                     "@john.doe-synapse.org:dev01.synapse.org",
                     "$2b$12$58YVjKsB58DM.YFChWQM8uP0x3rh1iaKDNSPl3Jv34LGqwn7tIure",
                     1700823160,
+                    0,
                     0
+                );
+                """,
+                (),
+            )
+            txn.execute(
+                """
+                INSERT INTO users VALUES (
+                    "@lex.luthor-synapse.org:dev01.synapse.org",
+                    "$2b$12$58YVjKsB58DM.YFChWQM8uP0x3rh1iaKDNSPl3Jv34LGqwn7tIure",
+                    1700823160,
+                    0,
+                    1
                 );
                 """,
                 (),


### PR DESCRIPTION
- Removes the migration of `account_validity` from synapse to this module table `email_account_validity`.
- It will send send email to all users and will not take into account the email status stored in account_validity
- Also make small improvement by activating the module only on activated users