### PR TITLE
do not send email to deactivated account

### DIFF
--- a/email_account_validity/_base.py
+++ b/email_account_validity/_base.py
@@ -115,6 +115,9 @@ class EmailAccountValidityBase:
         # deactivated, as a deactivated account isn't supposed to have any email address
         # attached to it.
         if not addresses:
+            logger.warning("No email addresses are defined for user_id=%s - threepids=%s",
+                           user_id,
+                           threepids)
             return
 
         try:
@@ -163,6 +166,9 @@ class EmailAccountValidityBase:
             )
 
         await self._store.set_renewal_mail_status(user_id=user_id, renewal_period_in_ts=renewal_period_in_ts, email_sent=True)
+        logger.debug("Email has been sent to user_id=%s, renewal_period_in_ts=%s",
+                     user_id,
+                     renewal_period_in_ts)
 
     def calculate_days_until_expiration(self, expiration_ts: int) -> int:
         SECONDS_PER_DAY = 86400

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -283,6 +283,7 @@ class EmailAccountValidityStore:
                 FROM email_account_validity eav
                 JOIN email_status_account_validity esav
                 ON eav.user_id = esav.user_id AND esav.email_sent = ?
+                JOIN users u ON u.name = eav.user_id AND u.deactivated = 0
                 GROUP BY eav.user_id, eav.expiration_ts_ms
                 HAVING (eav.expiration_ts_ms - ?) <= MAX(esav.renewal_period_in_ts)
                 """,

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -36,6 +36,7 @@ _TOKEN_COLUMN_NAME = {
 class EmailAccountValidityStore:
     def __init__(self, config: EmailAccountValidityConfig, api: ModuleApi):
         self._api = api
+        self.server_name = self._api.server_name
         self._period = config.period
         self._exclude_user_id_patterns = config.exclude_user_id_patterns
         self._send_renewal_email_at = config.send_renewal_email_at
@@ -282,7 +283,6 @@ class EmailAccountValidityStore:
                 FROM email_account_validity eav
                 JOIN email_status_account_validity esav
                 ON eav.user_id = esav.user_id AND esav.email_sent = ?
-                JOIN users u ON u.name = eav.user_id AND u.deactivated = 0
                 GROUP BY eav.user_id, eav.expiration_ts_ms
                 HAVING (eav.expiration_ts_ms - ?) <= MAX(esav.renewal_period_in_ts)
                 """,

--- a/email_account_validity/_store.py
+++ b/email_account_validity/_store.py
@@ -282,6 +282,7 @@ class EmailAccountValidityStore:
                 FROM email_account_validity eav
                 JOIN email_status_account_validity esav
                 ON eav.user_id = esav.user_id AND esav.email_sent = ?
+                JOIN users u ON u.name = eav.user_id AND u.deactivated = 0
                 GROUP BY eav.user_id, eav.expiration_ts_ms
                 HAVING (eav.expiration_ts_ms - ?) <= MAX(esav.renewal_period_in_ts)
                 """,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -131,6 +131,7 @@ async def create_account_validity_module(config={}) -> EmailAccountValidity:
     # because some capabilities (interacting with the database, getting the current time,
     # etc.) are needed for running the tests.
     module_api = mock.Mock(spec=ModuleApi)
+    module_api._hs = mock.Mock()
     module_api.run_db_interaction.side_effect = store.run_db_interaction
     module_api.read_templates.side_effect = read_templates
     module_api.get_profile_for_user.side_effect = get_profile_for_user

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -52,6 +52,81 @@ def populate_email_account_validity_with_existing_user(txn: LoggingTransaction, 
         (),
     )
 
+def create_user_table(txn: LoggingTransaction):
+    txn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users(
+        name TEXT,
+        password_hash TEXT,
+        creation_ts BIGINT UNSIGNED,
+        admin BOOL DEFAULT 0 NOT NULL,
+        deactivated smallint DEFAULT 0 NOT NULL,
+        UNIQUE(name)
+        );
+        """,
+        (),
+    )
+    txn.execute(
+        """
+        INSERT INTO users VALUES (
+            "@izzy-test:homeserver1",
+            "$2b$12$58YVjKsB58DM.YFChWQM8uP0x3rh1iaKDNSPl3Jv34LGqwn7tIure",
+            1700823133,
+            0,
+            0
+        );
+        """,
+        (),
+    )
+    txn.execute(
+        """
+        INSERT INTO users VALUES (
+            "@joe-test:homeserver1",
+            "$2b$12$58YVjKsB58DM.YFChWQM8uP0x3rh1iaKDNSPl3Jv34LGqwn7tIure",
+            1700823160,
+            0,
+            0
+        );
+        """,
+        (),
+    )
+    txn.execute(
+        """
+        INSERT INTO users VALUES (
+            "@albert-test:homeserver1",
+            "$2b$12$58YVjKsB58DM.YFChWQM8uP0x3rh1iaKDNSPl3Jv34LGqwn7tIure",
+            1700823160,
+            0,
+            1
+        );
+        """,
+        (),
+    )
+    txn.execute(
+        """
+        INSERT INTO users VALUES (
+            "@frida-test:homeserver1",
+            "$2b$12$58YVjKsB58DM.YFChWQM8uP0x3rh1iaKDNSPl3Jv34LGqwn7tIure",
+            1700823160,
+            0,
+            0
+        );
+        """,
+        (),
+    )
+
+    txn.execute(
+        """
+        INSERT INTO users VALUES (
+            "@rachel-test:homeserver1",
+            "$2b$12$58YVjKsB58DM.YFChWQM8uP0x3rh1iaKDNSPl3Jv34LGqwn7tIure",
+            1700823160,
+            0,
+            1
+        );
+        """,
+        (),
+    )
 
 class AccountValidityHooksTestCase(aiounittest.AsyncTestCase):
     async def test_user_expired(self):
@@ -556,7 +631,9 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
         self.assertEqual(9, len(res))
 
     async def test_get_users_expiring_soon(self):
+
         module = await create_account_validity_module()
+        await module._store._api.run_db_interaction("create_user_table", create_user_table, )
         now_ms = int(time.time() * 1000)
 
         user_id = "@izzy-test:homeserver1"
@@ -577,16 +654,29 @@ class AccountValidityEmailTestCase(aiounittest.AsyncTestCase):
             user_id=user_id3,
             expiration_ts=user_id_date3,
         )
+        user_id4 = "@frida-test:homeserver1"
+        user_id_date4 = now_ms - (10 * 24 * 60 * 60 * 1000)  # already expired : -10 days before
+        await module.renew_account_for_user(
+            user_id=user_id4,
+            expiration_ts=user_id_date4,
+        )
+        user_id5 = "@rachel-test:homeserver1"
+        user_id_date5 = now_ms - (10 * 24 * 60 * 60 * 1000)  # already expired and deactivated : -10 days before
+        await module.renew_account_for_user(
+            user_id=user_id5,
+            expiration_ts=user_id_date5,
+        )
 
         expiring_users = await module._store.get_users_expiring_soon()
 
-        self.assertEqual(2, len(expiring_users))
+        self.assertEqual(3, len(expiring_users))
 
     async def test_send_renewal_email(self):
         # conf :
         # "period": "6w",
         # "send_renewal_email_at": ["30d", "2w", "1w"],
         module = await create_account_validity_module()
+        await module._store._api.run_db_interaction("create_user_table", create_user_table, )
         now_ms = int(time.time() * 1000)
 
         threepids = {


### PR DESCRIPTION
- do not send email to deactivated account
- add logging if no email is found for a user
- fix also compatibility issue , registered cached function requires the owner class to defined a `server_name`