### PR TITLE
Fix_admin_api

### DIFF
--- a/email_account_validity/_servlets.py
+++ b/email_account_validity/_servlets.py
@@ -142,6 +142,15 @@ class EmailAccountValidityAdminServlet(
     EmailAccountValidityBase,
     DirectServeJsonResource,
 ):
+    def __init__(
+        self,
+        config: EmailAccountValidityConfig,
+        api: ModuleApi,
+        store: EmailAccountValidityStore,
+    ):
+        EmailAccountValidityBase.__init__(self, config, api, store)
+        DirectServeJsonResource.__init__(self)
+
     async def _async_render_POST(self, request):
         """On POST requests on /admin, update the given user with the given account
         validity state, if the requester is a server admin.


### PR DESCRIPTION
admin api was not well initialized : `/_synapse/client/email_account_validity/admin`
With MAS upgrade this API is necessary because the admin API is deactivated `/_synapse/admin/v1/account_validity/validity`